### PR TITLE
Rustfmt macros

### DIFF
--- a/constructor/src/fixed_hash/core/builtin/std_default.rs
+++ b/constructor/src/fixed_hash/core/builtin/std_default.rs
@@ -19,7 +19,7 @@ impl HashConstructor {
         let part = quote!(
             impl ::std::default::Default for #name {
                 #[inline]
-                fn default()  -> Self {
+                fn default() -> Self {
                     Self::zero()
                 }
             }

--- a/constructor/src/fixed_hash/core/builtin/std_fmt.rs
+++ b/constructor/src/fixed_hash/core/builtin/std_fmt.rs
@@ -109,12 +109,12 @@ impl HashConstructor {
                 write!(f, #write_tpl_padded, data[4])?;
                 write!(f, #write_tpl_padded, data[5])?;
                 write!(f, #omit)?;
-                write!(f, #write_tpl_padded, data[#unit_amount-6])?;
-                write!(f, #write_tpl_padded, data[#unit_amount-5])?;
-                write!(f, #write_tpl_padded, data[#unit_amount-4])?;
-                write!(f, #write_tpl_padded, data[#unit_amount-3])?;
-                write!(f, #write_tpl_padded, data[#unit_amount-2])?;
-                write!(f, #write_tpl_padded, data[#unit_amount-1])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 6])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 5])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 4])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 3])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 2])?;
+                write!(f, #write_tpl_padded, data[#unit_amount - 1])?;
             )
         } else {
             quote!(#(write!(f, #loop_write_tpl_padded, data[#loop_unit_amount])?;)*)

--- a/constructor/src/fixed_hash/core/builtin/std_ops.rs
+++ b/constructor/src/fixed_hash/core/builtin/std_ops.rs
@@ -38,7 +38,7 @@ impl HashConstructor {
         let part = quote!(
             impl<'a, Rhs> ::std::ops::#trait_name<Rhs> for &'a #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
@@ -48,7 +48,7 @@ impl HashConstructor {
             }
             impl<Rhs> ::std::ops::#trait_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
@@ -58,31 +58,28 @@ impl HashConstructor {
             }
             impl<Rhs> ::std::ops::#trait_assign_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 #[inline]
                 fn #func_assign_name(&mut self, other: Rhs) {
                     *self = self.#real_func(&other.into());
                 }
             }
-            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name
-            {
+            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &#name) -> Self::Output {
                     self.#real_func(other)
                 }
             }
-            impl<'a> ::std::ops::#trait_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_name<&'a #name> for #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &#name) -> Self::Output {
                     self.#real_func(other)
                 }
             }
-            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name {
                 #[inline]
                 fn #func_assign_name(&mut self, other: &#name) {
                     *self = self.#real_func(other);
@@ -124,7 +121,7 @@ impl HashConstructor {
             let uint_name = utils::ident_to_ts(uint_name);
             let real_func = utils::ident_to_ts(format!("_ush{}", direction).as_ref());
             let part = quote!(
-                impl<'a,'b> ::std::ops::#trait_name<&'a #uint_name> for &'b #name {
+                impl<'a, 'b> ::std::ops::#trait_name<&'a #uint_name> for &'b #name {
                     type Output = #name;
                     #[inline]
                     fn #func_name(self, other: &#uint_name) -> Self::Output {
@@ -173,7 +170,7 @@ impl HashConstructor {
             let int_name = utils::ident_to_ts(int_name);
             let real_func = utils::ident_to_ts(format!("_ish{}", direction).as_ref());
             let part = quote!(
-                impl<'a,'b> ::std::ops::#trait_name<&'a #int_name> for &'b #name {
+                impl<'a, 'b> ::std::ops::#trait_name<&'a #int_name> for &'b #name {
                     type Output = #name;
                     #[inline]
                     fn #func_name(self, other: &#int_name) -> Self::Output {
@@ -225,7 +222,7 @@ impl HashConstructor {
         let part = quote!(
             impl<Idx> ::std::ops::Index<Idx> for #name
             where
-                Idx: ::std::slice::SliceIndex<[u8], Output = [u8]>
+                Idx: ::std::slice::SliceIndex<[u8], Output = [u8]>,
             {
                 type Output = Idx::Output;
                 #[inline]
@@ -235,7 +232,7 @@ impl HashConstructor {
             }
             impl<Idx> ::std::ops::IndexMut<Idx> for #name
             where
-                Idx: ::std::slice::SliceIndex<[u8], Output = [u8]>
+                Idx: ::std::slice::SliceIndex<[u8], Output = [u8]>,
             {
                 #[inline]
                 fn index_mut(&mut self, index: Idx) -> &mut Idx::Output {

--- a/constructor/src/fixed_hash/core/constructor.rs
+++ b/constructor/src/fixed_hash/core/constructor.rs
@@ -118,7 +118,7 @@ impl HashConstructor {
         let part = quote!(
             /// Fixed hash type.
             #[derive(Clone)]
-            pub struct #name (pub #inner_type);
+            pub struct #name(pub #inner_type);
         );
         self.attach_hash(part);
     }

--- a/constructor/src/fixed_hash/core/extension/serde.rs
+++ b/constructor/src/fixed_hash/core/extension/serde.rs
@@ -24,30 +24,46 @@ impl HashConstructor {
         let part = quote!(
             #[cfg(feature = "support_serde")]
             impl serde::Serialize for #name {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
                     let bytes = self.as_bytes();
                     let mut dst = [0u8; #bytes_size * 2 + 2];
                     dst[0] = b'0';
                     dst[1] = b'x';
                     faster_hex::hex_to(bytes, &mut dst[2..])
                         .map_err(|e| serde::ser::Error::custom(&format!("{}", e)))?;
-                    serializer.serialize_str(unsafe {::std::str::from_utf8_unchecked(&dst)})
+                    serializer.serialize_str(unsafe { ::std::str::from_utf8_unchecked(&dst) })
                 }
             }
 
             #[cfg(feature = "support_serde")]
             impl<'de> serde::Deserialize<'de> for #name {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
                     struct Visitor;
 
                     impl<'b> serde::de::Visitor<'b> for Visitor {
                         type Value = #name;
 
-                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                            write!(formatter, "a 0x-prefixed hex string with {} digits", #bytes_size * 2)
+                        fn expecting(
+                            &self,
+                            formatter: &mut ::std::fmt::Formatter,
+                        ) -> ::std::fmt::Result {
+                            write!(
+                                formatter,
+                                "a 0x-prefixed hex string with {} digits",
+                                #bytes_size * 2
+                            )
                         }
 
-                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
                             if v.len() != #bytes_size * 2 + 2 {
                                 return Err(E::invalid_length(v.len() - 2, &self));
                             }
@@ -67,7 +83,10 @@ impl HashConstructor {
                             })
                         }
 
-                        fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
                             self.visit_str(&v)
                         }
                     }

--- a/constructor/src/fixed_hash/core/internal/kernel.rs
+++ b/constructor/src/fixed_hash/core/internal/kernel.rs
@@ -40,7 +40,8 @@ impl HashConstructor {
             let that_bytes_size = &uc.ts.unit_amount;
             quote!(
                 let mut ret = #that_name::zero();
-                ret.mut_inner().copy_from_slice(&self.inner()[..#that_bytes_size]);
+                ret.mut_inner()
+                    .copy_from_slice(&self.inner()[..#that_bytes_size]);
                 (ret, true)
             )
         };
@@ -61,7 +62,7 @@ impl HashConstructor {
             /// Create a new fixed hash with a provided input.
             #[inline]
             const fn new(data: #inner_type) -> Self {
-                #name (data)
+                #name(data)
             }
             /// Get a reference of the inner data of the fixed hash.
             #[inline]

--- a/constructor/src/fixed_uint/core/builtin/as_primitive.rs
+++ b/constructor/src/fixed_uint/core/builtin/as_primitive.rs
@@ -111,33 +111,53 @@ impl UintConstructor {
             #[inline]
             pub fn checked_add(&self, rhs: &Self) -> Option<Self> {
                 let (ret, of) = self._add(rhs);
-                if of { None } else { Some(ret) }
+                if of {
+                    None
+                } else {
+                    Some(ret)
+                }
             }
             /// Checked integer subtraction. Computes `self - rhs`,
             /// returning `None` if overflow occurred.
             #[inline]
             pub fn checked_sub(&self, rhs: &Self) -> Option<Self> {
                 let (ret, of) = self._sub(rhs);
-                if of { None } else { Some(ret) }
+                if of {
+                    None
+                } else {
+                    Some(ret)
+                }
             }
             /// Checked integer multiplication. Computes `self * rhs`,
             /// returning `None` if overflow occurred.
             #[inline]
             pub fn checked_mul(&self, rhs: &Self) -> Option<Self> {
                 let (ret, of) = self._mul(rhs);
-                if of { None } else { Some(ret) }
+                if of {
+                    None
+                } else {
+                    Some(ret)
+                }
             }
             /// Checked integer division. Computes `self / rhs`, returning `None` if `rhs == 0`.
             #[inline]
             pub fn checked_div(&self, rhs: &Self) -> Option<Self> {
                 let (ret, of) = self._div(rhs);
-                if of { None } else { Some(ret) }
+                if of {
+                    None
+                } else {
+                    Some(ret)
+                }
             }
             /// Checked integer remainder. Computes `self % rhs`, returning `None` if `rhs == 0`.
             #[inline]
             pub fn checked_rem(&self, rhs: &Self) -> Option<Self> {
                 let (ret, of) = self._rem(rhs);
-                if of { None } else { Some(ret) }
+                if of {
+                    None
+                } else {
+                    Some(ret)
+                }
             }
             /// Checked shift left. Computes `self << rhs`,
             /// returning `None` if `rhs` is larger than or equal to the number of bits in `self`.
@@ -180,21 +200,33 @@ impl UintConstructor {
             #[inline]
             pub fn saturating_add(&self, rhs: &Self) -> Self {
                 let (ret, of) = self._add(rhs);
-                if of { Self::max_value() } else { ret }
+                if of {
+                    Self::max_value()
+                } else {
+                    ret
+                }
             }
             /// Checked integer subtraction. Computes `self - rhs`,
             /// returning `None` if overflow occurred.
             #[inline]
             pub fn saturating_sub(&self, rhs: &Self) -> Self {
                 let (ret, of) = self._sub(rhs);
-                if of { Self::zero() } else { ret }
+                if of {
+                    Self::zero()
+                } else {
+                    ret
+                }
             }
             /// Checked integer multiplication. Computes `self * rhs`,
             /// returning `None` if overflow occurred.
             #[inline]
             pub fn saturating_mul(&self, rhs: &Self) -> Self {
                 let (ret, of) = self._mul(rhs);
-                if of { Self::max_value() } else { ret }
+                if of {
+                    Self::max_value()
+                } else {
+                    ret
+                }
             }
         );
         self.defun(part);
@@ -301,7 +333,7 @@ impl UintConstructor {
                     if of {
                         unreachable!();
                     }
-                    (val , true)
+                    (val, true)
                 }
             }
         );

--- a/constructor/src/fixed_uint/core/builtin/std_default.rs
+++ b/constructor/src/fixed_uint/core/builtin/std_default.rs
@@ -19,7 +19,7 @@ impl UintConstructor {
         let part = quote!(
             impl ::std::default::Default for #name {
                 #[inline]
-                fn default()  -> Self {
+                fn default() -> Self {
                     Self::zero()
                 }
             }

--- a/constructor/src/fixed_uint/core/builtin/std_fmt.rs
+++ b/constructor/src/fixed_uint/core/builtin/std_fmt.rs
@@ -95,10 +95,10 @@ impl UintConstructor {
                         write!(f, #write_tpl, data[idx])?;
                         idx -= 1;
                         while idx > 0 {
-                            write!(f, #write_tpl_padded, data[idx], width=#width)?;
+                            write!(f, #write_tpl_padded, data[idx], width = #width)?;
                             idx -= 1;
                         }
-                        write!(f, #write_tpl_padded, data[0], width=#width)
+                        write!(f, #write_tpl_padded, data[0], width = #width)
                     }
                 }
             }

--- a/constructor/src/fixed_uint/core/builtin/std_iter.rs
+++ b/constructor/src/fixed_uint/core/builtin/std_iter.rs
@@ -26,7 +26,7 @@ impl UintConstructor {
                 #[inline]
                 fn sum<I>(iter: I) -> Self
                 where
-                    I: ::std::iter::Iterator<Item = &'a #name>
+                    I: ::std::iter::Iterator<Item = &'a #name>,
                 {
                     iter.fold(Self::zero(), ::std::ops::Add::add)
                 }
@@ -35,7 +35,7 @@ impl UintConstructor {
                 #[inline]
                 fn sum<I>(iter: I) -> Self
                 where
-                    I: ::std::iter::Iterator<Item = #name>
+                    I: ::std::iter::Iterator<Item = #name>,
                 {
                     iter.fold(Self::zero(), ::std::ops::Add::add)
                 }
@@ -51,7 +51,7 @@ impl UintConstructor {
                 #[inline]
                 fn product<I>(iter: I) -> Self
                 where
-                    I: ::std::iter::Iterator<Item = &'a #name>
+                    I: ::std::iter::Iterator<Item = &'a #name>,
                 {
                     iter.fold(Self::one(), ::std::ops::Mul::mul)
                 }
@@ -60,7 +60,7 @@ impl UintConstructor {
                 #[inline]
                 fn product<I>(iter: I) -> Self
                 where
-                    I: ::std::iter::Iterator<Item = #name>
+                    I: ::std::iter::Iterator<Item = #name>,
                 {
                     iter.fold(Self::one(), ::std::ops::Mul::mul)
                 }

--- a/constructor/src/fixed_uint/core/builtin/std_ops.rs
+++ b/constructor/src/fixed_uint/core/builtin/std_ops.rs
@@ -52,65 +52,74 @@ impl UintConstructor {
         let part = quote!(
             impl<'a, Rhs> ::std::ops::#trait_name<Rhs> for &'a #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: Rhs) -> Self::Output {
                     let (ret, of) = self.#real_func(&other.into());
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     ret
                 }
             }
             impl<Rhs> ::std::ops::#trait_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: Rhs) -> Self::Output {
                     let (ret, of) = self.#real_func(&other.into());
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     ret
                 }
             }
             impl<Rhs> ::std::ops::#trait_assign_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 #[inline]
                 fn #func_assign_name(&mut self, other: Rhs) {
                     let (ret, of) = self.#real_func(&other.into());
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     *self = ret;
                 }
             }
-            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name
-            {
+            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &#name) -> Self::Output {
                     let (ret, of) = self.#real_func(other);
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     ret
                 }
             }
-            impl<'a> ::std::ops::#trait_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_name<&'a #name> for #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &'a #name) -> Self::Output {
                     let (ret, of) = self.#real_func(other);
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     ret
                 }
             }
-            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name {
                 #[inline]
                 fn #func_assign_name(&mut self, other: &#name) {
                     let (ret, of) = self.#real_func(other);
-                    if of { #panic_stmt }
+                    if of {
+                        #panic_stmt
+                    }
                     *self = ret;
                 }
             }
@@ -129,7 +138,7 @@ impl UintConstructor {
         let part = quote!(
             impl<'a, Rhs> ::std::ops::#trait_name<Rhs> for &'a #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
@@ -139,7 +148,7 @@ impl UintConstructor {
             }
             impl<Rhs> ::std::ops::#trait_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 type Output = #name;
                 #[inline]
@@ -149,31 +158,28 @@ impl UintConstructor {
             }
             impl<Rhs> ::std::ops::#trait_assign_name<Rhs> for #name
             where
-                Rhs: ::std::convert::Into<#name>
+                Rhs: ::std::convert::Into<#name>,
             {
                 #[inline]
                 fn #func_assign_name(&mut self, other: Rhs) {
                     *self = self.#real_func(&other.into());
                 }
             }
-            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name
-            {
+            impl<'a, 'b> ::std::ops::#trait_name<&'b #name> for &'a #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &#name) -> Self::Output {
                     self.#real_func(other)
                 }
             }
-            impl<'a> ::std::ops::#trait_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_name<&'a #name> for #name {
                 type Output = #name;
                 #[inline]
                 fn #func_name(self, other: &#name) -> Self::Output {
                     self.#real_func(other)
                 }
             }
-            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name
-            {
+            impl<'a> ::std::ops::#trait_assign_name<&'a #name> for #name {
                 #[inline]
                 fn #func_assign_name(&mut self, other: &#name) {
                     *self = self.#real_func(other);
@@ -215,7 +221,7 @@ impl UintConstructor {
             let uint_name = utils::ident_to_ts(uint_name);
             let real_func = utils::ident_to_ts(format!("_ush{}", direction).as_ref());
             let part = quote!(
-                impl<'a,'b> ::std::ops::#trait_name<&'a #uint_name> for &'b #name {
+                impl<'a, 'b> ::std::ops::#trait_name<&'a #uint_name> for &'b #name {
                     type Output = #name;
                     #[inline]
                     fn #func_name(self, other: &#uint_name) -> Self::Output {
@@ -264,7 +270,7 @@ impl UintConstructor {
             let int_name = utils::ident_to_ts(int_name);
             let real_func = utils::ident_to_ts(format!("_ish{}", direction).as_ref());
             let part = quote!(
-                impl<'a,'b> ::std::ops::#trait_name<&'a #int_name> for &'b #name {
+                impl<'a, 'b> ::std::ops::#trait_name<&'a #int_name> for &'b #name {
                     type Output = #name;
                     #[inline]
                     fn #func_name(self, other: &#int_name) -> Self::Output {

--- a/constructor/src/fixed_uint/core/constructor.rs
+++ b/constructor/src/fixed_uint/core/constructor.rs
@@ -144,7 +144,7 @@ impl UintConstructor {
         let part = quote!(
             /// Little-endian fixed integer type.
             #[derive(Clone)]
-            pub struct #name (pub #inner_type);
+            pub struct #name(pub #inner_type);
         );
         self.attach_uint(part);
     }

--- a/constructor/src/fixed_uint/core/extension/serde.rs
+++ b/constructor/src/fixed_uint/core/extension/serde.rs
@@ -24,7 +24,10 @@ impl UintConstructor {
         let part = quote!(
             #[cfg(feature = "support_serde")]
             impl serde::Serialize for #name {
-                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: serde::Serializer,
+                {
                     fn hex_to(src: &[u8], dst: &mut [u8]) -> usize {
                         fn hex(byte: u8) -> u8 {
                             static TABLE: &[u8] = b"0123456789abcdef";
@@ -50,7 +53,6 @@ impl UintConstructor {
                         len
                     }
 
-
                     let mut bytes = [0u8; #bytes_size];
                     let mut dst = [0u8; #bytes_size * 2 + 2];
                     dst[0] = b'0';
@@ -63,7 +65,9 @@ impl UintConstructor {
                     if let Some(non_zero_idx) = non_zero {
                         let bytes = &bytes[non_zero_idx..];
                         let len = hex_to(bytes, &mut dst[2..]);
-                        serializer.serialize_str(unsafe {::std::str::from_utf8_unchecked(&dst[..(len + 2)])})
+                        serializer.serialize_str(unsafe {
+                            ::std::str::from_utf8_unchecked(&dst[..(len + 2)])
+                        })
                     } else {
                         serializer.serialize_str("0x0")
                     }
@@ -72,18 +76,31 @@ impl UintConstructor {
 
             #[cfg(feature = "support_serde")]
             impl<'de> serde::Deserialize<'de> for #name {
-                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+                fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+                where
+                    D: serde::Deserializer<'de>,
+                {
                     struct Visitor;
 
                     impl<'b> serde::de::Visitor<'b> for Visitor {
                         type Value = #name;
 
-                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                            write!(formatter, "a 0x-prefixed hex string with at most {} digits", #bytes_size * 2)
+                        fn expecting(
+                            &self,
+                            formatter: &mut ::std::fmt::Formatter,
+                        ) -> ::std::fmt::Result {
+                            write!(
+                                formatter,
+                                "a 0x-prefixed hex string with at most {} digits",
+                                #bytes_size * 2
+                            )
                         }
 
-                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: serde::de::Error {
-                            if v.len() < 2  || &v[0..2] != "0x" {
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
+                            if v.len() < 2 || &v[0..2] != "0x" {
                                 return Err(E::custom(format_args!(
                                     "invalid format, expected {}",
                                     &self as &serde::de::Expected
@@ -102,7 +119,10 @@ impl UintConstructor {
                             })
                         }
 
-                        fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: serde::de::Error {
+                        fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                        where
+                            E: serde::de::Error,
+                        {
                             self.visit_str(&v)
                         }
                     }

--- a/constructor/src/fixed_uint/core/internal/kernel.rs
+++ b/constructor/src/fixed_uint/core/internal/kernel.rs
@@ -92,7 +92,7 @@ impl UintConstructor {
             /// Create a new fixed uint with a provided input.
             #[inline]
             const fn new(data: #inner_type) -> Self {
-                #name (data)
+                #name(data)
             }
             /// Get a reference of the inner data of the fixed uint.
             #[inline]

--- a/constructor/src/fixed_uint/core/internal/private_ops.rs
+++ b/constructor/src/fixed_uint/core/internal/private_ops.rs
@@ -180,12 +180,16 @@ impl UintConstructor {
                     let (val_n, of_n) = #unit_suffix::overflowing_add(lhs[#i], rhs[#i]);
                     // The carry only can be one.
                     let (val_o, of_o) = #unit_suffix::overflowing_add(val_n, 1);
-                    unsafe { ::std::ptr::write(ret_ptr.offset(#i), val_o); }
+                    unsafe {
+                        ::std::ptr::write(ret_ptr.offset(#i), val_o);
+                    }
                     // Can not overflow twice.
                     of_n || of_o
                 } else {
                     let (val_n, of_n) = #unit_suffix::overflowing_add(lhs[#i], rhs[#i]);
-                    unsafe { ::std::ptr::write(ret_ptr.offset(#i), val_n); }
+                    unsafe {
+                        ::std::ptr::write(ret_ptr.offset(#i), val_n);
+                    }
                     of_n
                 };
             );
@@ -199,8 +203,7 @@ impl UintConstructor {
                 let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
                 let ret_ptr = &mut ret as *mut #inner_type as *mut #unit_suffix;
                 let mut of = false;
-                #loop_part
-                (Self::new(ret), of)
+                #loop_part(Self::new(ret), of)
             }
         );
         self.defun(part);
@@ -217,12 +220,16 @@ impl UintConstructor {
                     let (val_n, of_n) = #unit_suffix::overflowing_sub(lhs[#i], rhs[#i]);
                     // The carry only can be one.
                     let (val_o, of_o) = #unit_suffix::overflowing_sub(val_n, 1);
-                    unsafe { ::std::ptr::write(ret_ptr.offset(#i), val_o); }
+                    unsafe {
+                        ::std::ptr::write(ret_ptr.offset(#i), val_o);
+                    }
                     // Can not overflow twice.
                     of_n || of_o
                 } else {
                     let (val_n, of_n) = #unit_suffix::overflowing_sub(lhs[#i], rhs[#i]);
-                    unsafe { ::std::ptr::write(ret_ptr.offset(#i), val_n); }
+                    unsafe {
+                        ::std::ptr::write(ret_ptr.offset(#i), val_n);
+                    }
                     of_n
                 };
             );
@@ -236,8 +243,7 @@ impl UintConstructor {
                 let mut ret: #inner_type = unsafe { ::std::mem::uninitialized() };
                 let ret_ptr = &mut ret as *mut #inner_type as *mut #unit_suffix;
                 let mut of = false;
-                #loop_part
-                (Self::new(ret), of)
+                #loop_part(Self::new(ret), of)
             }
         );
         self.defun(part);
@@ -256,7 +262,7 @@ impl UintConstructor {
                     let lidx_max_opt = self._highest_nonzero_unit();
                     let ridx_max_opt = other._highest_nonzero_unit();
                     if lidx_max_opt.is_none() || ridx_max_opt.is_none() {
-                        return (Self::zero(), false)
+                        return (Self::zero(), false);
                     }
                     (lidx_max_opt.unwrap(), ridx_max_opt.unwrap())
                 };
@@ -280,7 +286,9 @@ impl UintConstructor {
                         let mut k = lidx + ridx;
 
                         // store low part of current result
-                        if k >= #unit_amount { break; }
+                        if k >= #unit_amount {
+                            break;
+                        }
 
                         let lx = lhs[lidx] as #double_unit_suffix;
                         let rx = rhs[ridx] as #double_unit_suffix;
@@ -494,7 +502,9 @@ impl UintConstructor {
                     let lhs_highest = copy.inner()[lhs_idx] as #double_unit_suffix;
                     // if lhs highest byte is ZERO, the skip it
                     if lhs_highest == 0 {
-                        if ret_idx == 0 { break; }
+                        if ret_idx == 0 {
+                            break;
+                        }
                         ret_idx -= 1;
                         lhs_idx -= 1;
                         continue;
@@ -505,10 +515,13 @@ impl UintConstructor {
                     let dividend = if lhs_highest >= divisor {
                         lhs_highest
                     } else {
-                        if ret_idx == 0 { break; }
+                        if ret_idx == 0 {
+                            break;
+                        }
                         lhs_idx -= 1;
                         ret_idx -= 1;
-                        (lhs_highest << #unit_bits_size) + copy.inner()[lhs_idx] as #double_unit_suffix
+                        (lhs_highest << #unit_bits_size)
+                            + copy.inner()[lhs_idx] as #double_unit_suffix
                     };
                     let quotient = (dividend / divisor) as #unit_suffix;
                     let of = {
@@ -519,14 +532,14 @@ impl UintConstructor {
                     };
                     if of {
                         // `ret[ret_idx+1]+1` could not overflow
-                        ret[ret_idx+1] += 1;
+                        ret[ret_idx + 1] += 1;
                     }
                     let minuend = {
                         let (mut minuend_tmp, _) = other._mul_unit(quotient);
                         // left shift
                         let mut idx = #unit_amount - 1;
                         while idx > ret_idx {
-                            minuend_tmp.mut_inner()[idx] = minuend_tmp.inner()[idx-ret_idx];
+                            minuend_tmp.mut_inner()[idx] = minuend_tmp.inner()[idx - ret_idx];
                             idx -= 1;
                         }
                         minuend_tmp.mut_inner()[ret_idx] = minuend_tmp.inner()[0];

--- a/rustfmt-quote.py
+++ b/rustfmt-quote.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import sys
+import os
+import subprocess
+import re
+import io
+
+RUSTFMT_PATH = os.getenv('RUSTFMT_PATH', 'rustfmt')
+SPACE_PATTERN = re.compile(' *')
+START_PATTERN = re.compile('quote!\s*[({]$')
+QUOTE_TOKEN_PATTERN = re.compile('#([_a-zA-Z][_a-zA-Z0-9]*)')
+
+MOD_BLOCK_PATTERN = re.compile(
+    r'(?m)^\s*    (?:impl[ <]|(?:pub )?trait)')
+FN_BLOCK_PATTERN = re.compile(
+    r'(?m)^\s*    (?:pub |const )?fn ')
+
+MOD_START = "mod rustfmt {\n".encode('utf-8')
+IMPL_START = "impl Rustfmt {\n".encode('utf-8')
+FN_START = "fn rustfmt() {\n".encode('utf-8')
+ENUM_START = "enum Rustfmt {\n".encode('utf-8')
+MOD_END = "}\n".encode('utf-8')
+
+# Code that should not run rustfmt in the quote block
+BLACKLIST = re.compile(
+    r'(?m)^\s*(?:#(?:errors|preludes|defuns|part_core)|}?\)\*)\s*$')
+
+
+def write_block(block, indent, file):
+    for _ in range(indent - 1):
+        file.write(MOD_START)
+
+    if block.endswith(",\n"):
+        file.write(ENUM_START)
+    elif MOD_BLOCK_PATTERN.search(block) is not None:
+        file.write(MOD_START)
+    elif FN_BLOCK_PATTERN.search(block) is not None:
+        if 'self' in block:
+            file.write(IMPL_START)
+        else:
+            file.write(MOD_START)
+    else:
+        file.write(FN_START)
+
+    file.write(QUOTE_TOKEN_PATTERN.sub(u'Δ\\1', block).encode('utf-8'))
+    for _ in range(indent):
+        file.write(MOD_END)
+
+
+def rustfmt(block, indent):
+    # whitelist
+    if BLACKLIST.search(block) is not None:
+        return
+
+    rustfmt = subprocess.Popen(
+        RUSTFMT_PATH, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    write_block(block, indent, rustfmt.stdin)
+    rustfmt.stdin.close()
+
+    if rustfmt.wait() == 0:
+        outlines = [l.decode('utf-8').replace(u'Δ', u'#')
+                    for l in rustfmt.stdout.readlines()]
+        return u''.join(outlines[indent:-indent])
+    else:
+        write_block(block, indent, sys.stderr)
+        sys.stderr.write(rustfmt.stderr.read())
+
+
+def rustfmt_quote(path):
+    indent = 0
+    end_pattern = re.compile('[})]')
+    in_quote = False
+    out_lines = []
+    quote_lines = []
+    changed = False
+
+    with io.open(path, encoding='utf-8') as file:
+        for line in file:
+            if in_quote:
+                if end_pattern.match(line) is not None:
+                    in_quote = False
+                    block = u''.join(quote_lines)
+                    fmt_result = rustfmt(block, indent)
+                    if fmt_result is not None and fmt_result != block:
+                        changed = True
+                        out_lines.append(fmt_result)
+                    else:
+                        out_lines.append(block)
+
+                    out_lines.append(line)
+                else:
+                    quote_lines.append(line)
+            else:
+                out_lines.append(line)
+                if START_PATTERN.search(line) is not None:
+                    in_quote = True
+                    quote_lines = []
+                    leading_spaces = SPACE_PATTERN.match(line).group()
+                    indent = int(len(leading_spaces) / 4) + 1
+                    end_pattern = re.compile('^{}[)}}]'.format(leading_spaces))
+
+    if changed:
+        with io.open(path, 'w', encoding='utf-8') as file:
+            for line in out_lines:
+                file.write(line)
+
+    return len(quote_lines) > 0
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) == 1:
+        for root, dirs, files in os.walk('.'):
+            if '.git' in dirs:
+                dirs.remove('.git')
+            if 'target' in dirs:
+                dirs.remove('target')
+
+            for name in files:
+                if name.endswith('.rs'):
+                    path = os.path.join(root, name)
+                    if rustfmt_quote(path):
+                        print('rustfmt_quote {}'.format(path))
+
+    else:
+        for arg in sys.argv[1:]:
+            rustfmt_quote(arg)


### PR DESCRIPTION
Script `rustfmt-quote.py` is stupid but it works.

I have tried to write it in Bash, but it is too slow. The reason to choose Python is that it is built-in in most system.

The script first extracts the code between `quote!` and replace the macro variables in it.

Then it surrounds the code in the correct context, and run `rustfmt` against it.

However, some macro code still fails to pass `rustfmt`, so a blacklist is used to skip these kinds of code.